### PR TITLE
Update: Exclude reverted commits (fixes #3)

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -148,6 +148,71 @@ function getVersionTags() {
 // }
 
 /**
+ * Extracts data from a commit log in the format --pretty=format:"* %h %s (%an)\n%b".
+ * @param {string[]} logs Output from git log command.
+ * @returns {Object} An object containing the data exracted from the commit log.
+ * @private
+ */
+function parseLogs(logs) {
+    var regexp = /^(?:\* )?([0-9a-f]{7}) ((?:([a-z]+): ?)?.*) \((.*)\)/i,
+        parsed = [];
+
+    logs.forEach(function(log) {
+        var match = log.match(regexp);
+
+        if (match) {
+            parsed.push({
+                raw: match[0],
+                sha: match[1],
+                title: match[2],
+                flag: match[3] ? match[3].toLowerCase() : null,
+                author: match[4],
+                body: ""
+            });
+        } else {
+            parsed[parsed.length - 1].body += log + "\n";
+        }
+    });
+
+    return parsed;
+}
+
+/**
+ * Given a list of parsed commit log messages, excludes revert commits and the
+ * commits they reverted.
+ * @param {Object[]} logs An array of parsed commit log messages.
+ * @returns {Object[]} An array of parsed commit log messages.
+ */
+function excludeReverts(logs) {
+    logs = logs.slice();
+
+    var revertRegex = /This reverts commit ([0-9a-f]{40})/,
+        shaIndexMap = Object.create(null), // Map of commit shas to indices
+        i, log, match, sha;
+
+    // iterate in reverse because revert commits have lower indices than the
+    // commits they revert
+    for (i = logs.length - 1; i >= 0; i--) {
+        log = logs[i];
+        match = log.body.match(revertRegex);
+
+        if (match) {
+            sha = match[1].slice(0, 7);
+
+            // only exclude this revert if we can find the commit it reverts
+            if (typeof shaIndexMap[sha] !== "undefined") {
+                logs[shaIndexMap[sha]] = null;
+                logs[i] = null;
+            }
+        } else {
+            shaIndexMap[log.sha] = i;
+        }
+    }
+
+    return logs.filter(Boolean);
+}
+
+/**
  * Inspects an array of git commit log messages and calculates the release
  * information based on it.
  * @param {string} currentVersion The version of the project read from package.json.
@@ -158,24 +223,31 @@ function getVersionTags() {
  */
 function calculateReleaseFromGitLogs(currentVersion, logs, prereleaseId) {
 
-    var commitFlagPattern = /([a-z]+):/i,
-        changelog = {},
+    logs = excludeReverts(parseLogs(logs));
+
+    var changelog = {},
         releaseInfo = {
             version: currentVersion,
             type: "",
             changelog: changelog,
-            rawChangelog: logs.join("\n")
+            rawChangelog: logs.map(function(log) {
+                return log.raw;
+            }).join("\n")
         };
 
     // arrange change types into categories
     logs.forEach(function(log) {
-        var flag = log.match(commitFlagPattern)[1].toLowerCase();
 
-        if (!changelog[flag]) {
-            changelog[flag] = [];
+        // exclude untagged (e.g. revert) commits from version calculation
+        if (!log.flag) {
+            return;
         }
 
-        changelog[flag].push(log);
+        if (!changelog[log.flag]) {
+            changelog[log.flag] = [];
+        }
+
+        changelog[log.flag].push(log.raw);
     });
 
     if (changelog.breaking) {
@@ -211,7 +283,7 @@ function calculateReleaseInfo(prereleaseId) {
         commitRange = lastTag ? lastTag + "..HEAD" : "";
 
     // get log statements
-    var logs = ShellOps.execSilent("git log --no-merges --pretty=format:\"* %h %s (%an)\" " + commitRange).split(/\n/g);
+    var logs = ShellOps.execSilent("git log --no-merges --pretty=format:\"* %h %s (%an)\n%b\" " + commitRange).split(/\n/g);
 
     return calculateReleaseFromGitLogs(pkg.version, logs, prereleaseId);
 }

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -49,9 +49,9 @@ describe("ReleaseOps", function() {
 
         it("should create a patch release when only bug fixes are present", function() {
             var logs = [
-                    "Fix: Something",
-                    "Docs: Something else",
-                    "Fix: Something else"
+                    "* abcdef0 Fix: Something (Foo Bar)",
+                    "* 1234567 Docs: Something else (foobar)",
+                    "* a1b2c3d Fix: Something else (Foo B. Baz)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -60,11 +60,11 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     fix: [
-                        "Fix: Something",
-                        "Fix: Something else"
+                        "* abcdef0 Fix: Something (Foo Bar)",
+                        "* a1b2c3d Fix: Something else (Foo B. Baz)"
                     ],
                     docs: [
-                        "Docs: Something else"
+                        "* 1234567 Docs: Something else (foobar)"
                     ]
                 },
                 rawChangelog: logs.join("\n")
@@ -73,10 +73,10 @@ describe("ReleaseOps", function() {
 
         it("should create a minor release when enhancements are present", function() {
             var logs = [
-                    "Fix: Something",
-                    "Docs: Something else",
-                    "Fix: Something else",
-                    "Update: Foo"
+                    "* f9e8d7c Fix: Something (Author Name)",
+                    "* facecab Docs: Something else (authorname)",
+                    "* dec0ded Fix: Something else (First Last)",
+                    "* facade5 Update: Foo (dotstar)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -85,14 +85,14 @@ describe("ReleaseOps", function() {
                 type: "minor",
                 changelog: {
                     fix: [
-                        "Fix: Something",
-                        "Fix: Something else"
+                        "* f9e8d7c Fix: Something (Author Name)",
+                        "* dec0ded Fix: Something else (First Last)"
                     ],
                     docs: [
-                        "Docs: Something else"
+                        "* facecab Docs: Something else (authorname)"
                     ],
                     update: [
-                        "Update: Foo"
+                        "* facade5 Update: Foo (dotstar)"
                     ]
                 },
                 rawChangelog: logs.join("\n")
@@ -101,11 +101,11 @@ describe("ReleaseOps", function() {
 
         it("should create a major release when breaking changes are present", function() {
             var logs = [
-                    "Fix: Something",
-                    "Docs: Something else",
-                    "Fix: Something else",
-                    "Update: Foo",
-                    "Breaking: Whatever"
+                    "* abcd123 Fix: Something (githubhandle)",
+                    "* a1b2c3d Docs: Something else (Committer Name)",
+                    "* 321dcba Fix: Something else (Abc D. Efg)",
+                    "* 9876543 Update: Foo (Tina Tester)",
+                    "* 1234567 Breaking: Whatever (Toby Testing)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -114,30 +114,69 @@ describe("ReleaseOps", function() {
                 type: "major",
                 changelog: {
                     fix: [
-                        "Fix: Something",
-                        "Fix: Something else"
+                        "* abcd123 Fix: Something (githubhandle)",
+                        "* 321dcba Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "Docs: Something else"
+                        "* a1b2c3d Docs: Something else (Committer Name)"
                     ],
                     update: [
-                        "Update: Foo"
+                        "* 9876543 Update: Foo (Tina Tester)"
                     ],
                     breaking: [
-                        "Breaking: Whatever"
+                        "* 1234567 Breaking: Whatever (Toby Testing)"
                     ]
                 },
                 rawChangelog: logs.join("\n")
             });
         });
 
+        it("should disregard reverted commits", function() {
+            var logs = [
+                    "* abcd123 Docs: Update something in the docs (githubhandle)",
+                    "This is the body.",
+                    "It has multiple lines.",
+                    "* a1b2c3d Revert \"Breaking: A breaking change (fixes #1234)\" (Committer Name)",
+                    "This reverts commit abcdef010c481d5da8d2d9b5ef74945e6566166c.",
+                    "This explains why.",
+                    "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
+                    "Describe the bug.",
+                    "* 9876543 Revert \"New: Add cool new feature (fixes #42)\" (Tina Tester)",
+                    "This reverts commit 123456710c481d5da8d2d9b5ef74945e6566166c.",
+                    "* abcdef0 Breaking: A breaking change (fixes #1234) (Cool Committer)",
+                    "* 1234abc Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)",
+                    "This reverts commit 0123456789abcdeffedcba9876543210a1b2c3d4.",
+                    "* 1234567 New: Add cool new feature (fixes #42) (Toby Testing)",
+                    "Something about this change."
+                ],
+                releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
+
+            assert.deepEqual(releaseInfo, {
+                version: "1.0.1",
+                type: "patch",
+                changelog: {
+                    docs: [
+                        "* abcd123 Docs: Update something in the docs (githubhandle)"
+                    ],
+                    fix: [
+                        "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)"
+                    ]
+                },
+                rawChangelog: [
+                    "* abcd123 Docs: Update something in the docs (githubhandle)",
+                    "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
+                    "* 1234abc Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)"
+                ].join("\n")
+            });
+        });
+
         it("should create a prerelease when passed a prereleaseId", function() {
             var logs = [
-                    "Fix: Something",
-                    "Docs: Something else",
-                    "Fix: Something else",
-                    "Update: Foo",
-                    "Breaking: Whatever"
+                    "* abcd123 Fix: Something (githubhandle)",
+                    "* a1b2c3d Docs: Something else (Committer Name)",
+                    "* 321dcba Fix: Something else (Abc D. Efg)",
+                    "* 9876543 Update: Foo (Tina Tester)",
+                    "* 1234567 Breaking: Whatever (Cool Committer)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs, "alpha");
 
@@ -146,17 +185,17 @@ describe("ReleaseOps", function() {
                 type: "major",
                 changelog: {
                     fix: [
-                        "Fix: Something",
-                        "Fix: Something else"
+                        "* abcd123 Fix: Something (githubhandle)",
+                        "* 321dcba Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "Docs: Something else"
+                        "* a1b2c3d Docs: Something else (Committer Name)"
                     ],
                     update: [
-                        "Update: Foo"
+                        "* 9876543 Update: Foo (Tina Tester)"
                     ],
                     breaking: [
-                        "Breaking: Whatever"
+                        "* 1234567 Breaking: Whatever (Cool Committer)"
                     ]
                 },
                 rawChangelog: logs.join("\n")
@@ -165,9 +204,9 @@ describe("ReleaseOps", function() {
 
         it("should create a prerelease when passed a prereleaseId and prerelease version", function() {
             var logs = [
-                    "Fix: Something",
-                    "Docs: Something else",
-                    "Fix: Something else"
+                    "* abcd123 Fix: Something (githubhandle)",
+                    "* a1b2c3d Docs: Something else (Committer Name)",
+                    "* 321dcba Fix: Something else (Abc D. Efg)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("2.0.0-alpha.0", logs, "alpha");
 
@@ -176,11 +215,11 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     fix: [
-                        "Fix: Something",
-                        "Fix: Something else"
+                        "* abcd123 Fix: Something (githubhandle)",
+                        "* 321dcba Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "Docs: Something else"
+                        "* a1b2c3d Docs: Something else (Committer Name)"
                     ]
                 },
                 rawChangelog: logs.join("\n")


### PR DESCRIPTION
When generating changelogs or calculating new versions, reverted commits are ignored. For example:

```
* abcd123 Docs: Update something in the docs (githubhandle)
* a1b2c3d Revert "Breaking: A breaking change (fixes #1234)" (Committer Name)
* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)
* 9876543 Revert "New: Add cool new feature (fixes #42)" (Tina Tester)
* abcdef0 Breaking: A breaking change (fixes #1234) (Cool Committer)
* 1234abc Revert "New: From a previous release (fixes #1234)" (Foo Bar)
* 1234567 New: Add cool new feature (fixes #42) (Toby Testing)
```

Will become:

```
* abcd123 Docs: Update something in the docs (githubhandle)
* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)
```

And the new version will be a patch bump.

`calculateReleaseFromGitLogs` is only called from `calculateReleaseInfo`, so we can safely assume the logs are in the format `--pretty=format:"* %h %s (%an)"` as specified in `calculateReleaseInfo`. Though `calculateReleaseFromGitLogs` is included in `module.exports`, it is marked as `@private`, so I didn't label this as a breaking change.