### PR TITLE
Revert mistakenly pushed 0.4.0-alpha.5 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-v0.4.0-alpha.5 - March 25, 2016
-
-
-
 v0.4.0-alpha.4 - March 24, 2016
 
 * 2578f31 Fix: Changelog output (Nicholas C. Zakas)

--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -169,7 +169,7 @@ function parseLogs(logs) {
                 author: match[4],
                 body: ""
             });
-        } else if (parsed.length) {
+        } else {
             parsed[parsed.length - 1].body += log + "\n";
         }
     });
@@ -368,9 +368,9 @@ function release(prereleaseId) {
 
     // if there's a prerelease ID, publish under "next" tag
     if (prereleaseId) {
-        console.log("npm publish --tag next");
+        ShellOps.exec("npm publish --tag next");
     } else {
-        console.log("npm publish");
+        ShellOps.exec("npm publish");
     }
 
     // undo any line fix differences

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-release",
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.4",
   "description": "ESLint Release Tools",
   "main": "./lib/release-ops",
   "engines": {

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -226,29 +226,6 @@ describe("ReleaseOps", function() {
             });
         });
 
-        it("should gracefully handle unformatted commit messages", function() {
-            var logs = [
-                    "* 059f6bd 0.4.0-alpha.4 (Nicholas C. Zakas)",
-                    "* 6b498ed Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
-                    "* 2578f31 Fix: Changelog output (Nicholas C. Zakas)"
-                ],
-                releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("0.4.0-alpha.4", logs, "alpha");
-
-            assert.deepEqual(releaseInfo, {
-                version: "0.4.0-alpha.5",
-                type: "patch",
-                changelog: {
-                    build: [
-                        "* 6b498ed Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)"
-                    ],
-                    fix: [
-                        "* 2578f31 Fix: Changelog output (Nicholas C. Zakas)"
-                    ]
-                },
-                rawChangelog: logs.join("\n")
-            });
-        });
-
     });
 
 });


### PR DESCRIPTION
This reverts commit f48c89825a5ea4373208247a3b9d836de6eb09a3.
This reverts commit 6af47e2b925b89ef4e22cad5716869fcb604d03a.

This reverts changes mistakenly pushed as `0.4.0-alpha.5` while confirming the fix for #5.