### PR TITLE
Fix: commit only modifies changelog

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -383,8 +383,8 @@ function release(prereleaseId, ciRelease) {
     // ShellOps.exec("bundle-dependencies update");
 
     console.log("Committing to git");
-    ShellOps.exec("git add CHANGELOG.md package.json");
-    ShellOps.exec("git commit -m \"Build: package.json and changelog update for " + releaseInfo.version + "\"");
+    ShellOps.exec("git add CHANGELOG.md");
+    ShellOps.exec("git commit -m \"Build: changelog update for " + releaseInfo.version + "\"");
 
     console.log("Generating %s", releaseInfo.version);
     ShellOps.execSilent("npm version " + releaseInfo.version);


### PR DESCRIPTION
`package.json` is modified in a subsequent commit through `npm version`