### PR TITLE
Fix: gracefully handle shorthashes longer than 7 characters (fixes #15)

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -175,7 +175,7 @@ function getVersionTags() {
  * @private
  */
 function parseLogs(logs) {
-    var regexp = /^(?:\* )?([0-9a-f]{7}) ((?:([a-z]+): ?)?.*) \((.*)\)/i,
+    var regexp = /^(?:\* )?([0-9a-f]{7,}) ((?:([a-z]+): ?)?.*) \((.*)\)/i,
         parsed = [];
 
     logs.forEach(function(log) {

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -249,6 +249,29 @@ describe("ReleaseOps", function() {
             });
         });
 
+        // https://github.com/eslint/eslint-release/issues/15
+        it("should gracefully handle commit shorthashes longer than 7 characters", function() {
+            var logs = [
+                    "* 6b498edabcde Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
+                    "* 2578f31000 Fix: Changelog output (Nicholas C. Zakas)"
+                ],
+                releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("0.4.0-alpha.4", logs, "alpha");
+
+            assert.deepEqual(releaseInfo, {
+                version: "0.4.0-alpha.5",
+                type: "patch",
+                changelog: {
+                    build: [
+                        "* 6b498edabcde Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)"
+                    ],
+                    fix: [
+                        "* 2578f31000 Fix: Changelog output (Nicholas C. Zakas)"
+                    ]
+                },
+                rawChangelog: logs.join("\n")
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
This updates the changelog generator to gracefully handle commit hashes longer than 7 characters. Long shorthashes like this can be produced by newer versions of git when working with a large repository. Previously, the release tool would skip any commits with long hashes (resulting in an empty changelog).

With this implementation, the long shorthashes will be included in the changelog rather than being truncated. One disadvantage of doing it this way is that the changelog might be inconsistent -- it could vary between 7-character and 8-character shorthashes depending on the version of git installed on the release machine. However, this does reduce the risk of generating broken links due to ambiguous commit hashes, which is the whole point of having longer shorthashes anyway.

Fixes https://github.com/eslint/eslint-release/issues/15