### PR TITLE
Update: publish release notes to GitHub when doing a prerelease

### DIFF
--- a/bin/eslint-prerelease.js
+++ b/bin/eslint-prerelease.js
@@ -32,4 +32,5 @@ if (!prereleaseId) {
     process.exit(1);    // eslint-disable-line no-process-exit
 }
 
-ReleaseOps.release(prereleaseId);
+var releaseInfo = ReleaseOps.release(prereleaseId);
+ReleaseOps.publishReleaseToGitHub(releaseInfo);


### PR DESCRIPTION
This will make it easier to do prereleases of packages like `espree` from CI.