### PR TITLE
Fix: Mark prerelease notes as "prereleases" on GitHub

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -460,7 +460,8 @@ function publishReleaseToGitHub(releaseInfo) {
 
     return repo.createRelease({
         tag_name: tag,
-        body: releaseInfo.rawChangelog
+        body: releaseInfo.rawChangelog,
+        prerelease: !!semver.prerelease(releaseInfo.version)
     }).then(function() {
         console.log("Posted release notes to GitHub");
     }).catch(function(ex) {


### PR DESCRIPTION
GitHub has a feature where releases can be marked as "prereleases", which slightly changes how they are displayed. This updates the release tool to apply that marking when the current release is a prerelease.