### PR TITLE
Docs: should install globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that while this project is shared freely, it is not intended to be a
 You can install the ESLint release tool using [npm](https://npmjs.com):
 
 ```
-$ npm install eslint-release --save-dev
+$ npm install eslint-release -g
 ```
 
 ## Local Usage


### PR DESCRIPTION
following the steps in readme:
```bash
npm i eslint-release -D
./node_modules/.bin/eslint-release
```
got `could not remove directory (code ENOTEMPTY): node_modules/.bin`. seems it's trying to remove itself. 😂