### PR TITLE
Fix: avoid outputting broken publish command when OTP is provided

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -371,7 +371,7 @@ function publishRelease() {
     }
 
     if (process.env.NPM_OTP && /^\d+$/.test(process.env.NPM_OTP)) {
-        command += "--otp=" + process.env.NPM_OTP;
+        command += " --otp=" + process.env.NPM_OTP;
     }
 
     ShellOps.exec(command);


### PR DESCRIPTION
Previously, the script would run `npm publish--otp=123456` due to a missing space before the `--otp` flag.