### PR TITLE
Update: avoid unnecessary checks for environment variables

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -62,8 +62,13 @@ function validateSetup() {
         console.error("The 'repository' field must be in the format 'foo/bar' in package.json");
         ShellOps.exit(1);
     }
+}
 
-    // check NPM_TOKEN
+/**
+ * Verify that the appropriate credentials are present before publishing a release
+ * @returns {void}
+ */
+function validateEnvironment() {
     if (!process.env.NPM_TOKEN) {
         console.error("Missing NPM_TOKEN environment variable");
         ShellOps.exit(1);
@@ -360,6 +365,7 @@ function publishReleaseToGitHub(releaseInfo) {
  */
 function publishRelease() {
     validateSetup();
+    validateEnvironment();
     var releaseInfo = JSON.parse(fs.readFileSync(".eslint-release-info.json", "utf8"));
 
     // if there's a prerelease ID, publish under "next" tag


### PR DESCRIPTION
Currently, eslint-release requires `NPM_TOKEN` and `ESLINT_GITHUB_TOKEN` environment variables to be present when generating a release in addition to publishing a release. However, the tokens aren't necessary when generating a release, and requiring them makes it more difficult to test-generate a release locally. With this commit, the tokens are only validated when publishing, not when generating.