### PR TITLE
Fix: avoid overwriting the .npmrc file in a repository

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -320,9 +320,6 @@ function generateRelease(prereleaseId) {
         }
     });
 
-    // Release needs a .npmrc file to work properly - token is read from environment
-    console.log("Writing .npmrc file");
-    fs.writeFileSync(".npmrc", "//registry.npmjs.org/:_authToken=${NPM_TOKEN}");
     fs.writeFileSync(".eslint-release-info.json", JSON.stringify(releaseInfo, null, 4));
 }
 
@@ -362,6 +359,17 @@ function publishRelease() {
     validateSetup();
     var releaseInfo = JSON.parse(fs.readFileSync(".eslint-release-info.json", "utf8"));
 
+    var oldNpmrcContents;
+    if (fs.existsSync(".npmrc")) {
+        oldNpmrcContents = fs.readFileSync(".npmrc", "utf8");
+    } else {
+        oldNpmrcContents = null;
+    }
+
+    // Release needs a .npmrc file to work properly - token is read from environment
+    console.log("Writing .npmrc file");
+    fs.writeFileSync(".npmrc", "//registry.npmjs.org/:_authToken=${NPM_TOKEN}");
+
     // if there's a prerelease ID, publish under "next" tag
     console.log("Publishing to npm");
 
@@ -375,6 +383,12 @@ function publishRelease() {
     }
 
     ShellOps.exec(command);
+
+    if (oldNpmrcContents === null) {
+        fs.unlinkSync(".npmrc");
+    } else {
+        fs.writeFileSync(".npmrc", oldNpmrcContents);
+    }
 
     console.log("Publishing to git");
     ShellOps.exec("git push origin master --tags");


### PR DESCRIPTION
The release process needs to temporarily write an .npmrc file in order to publish. As a result, if the repository already has an .npmrc file, this will leave the file in a modified state. This isn't a big problem (it happens after creating a git commit, so the updated .npmrc file doesn't get published anywhere), but it has the potential to be confusing or cause human errors when generating a release locally. This commit updates the release publishing process to restore the old .npmrc file after the release finishes