### PR TITLE
Update: avoid printing TOTP to output when publishing

### DIFF
--- a/lib/shell-ops.js
+++ b/lib/shell-ops.js
@@ -74,7 +74,7 @@ module.exports = {
      * @private
      */
     exec: function(cmd) {
-        console.log("+ " + cmd);
+        console.log("+ " + cmd.replace(/--otp=\d+/g, "--otp=(redacted)"));
         var result = this.execSilent(cmd);
         console.log(result);
     },


### PR DESCRIPTION
This prevents the npm 2FA code from being printed to standard output. As a result, an attacker who had compromised an npm access token and also had access to build output would no longer be able to obtain a TOTP and use it in the next 30 seconds.

I tested this by generating a release locally and then running `npm run publish-release`. As expected, the TOTP was redacted in the output (and then the release failed without doing anything because I supplied an invalid access token for the test).