### PR TITLE
Update: include links to commits on GitHub in changelogs

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -122,7 +122,7 @@ function getVersionTags() {
  * @private
  */
 function parseLogs(logs) {
-    var regexp = /^(?:\* )?([0-9a-f]{7,}) ((?:([a-z]+): ?)?.*) \((.*)\)/i,
+    var regexp = /^\* ([0-9a-f]{40}) ((?:([a-z]+): ?)?.*) \((.*)\)/i,
         parsed = [];
 
     logs.forEach(function(log) {
@@ -165,7 +165,7 @@ function excludeReverts(logs) {
         match = log.body.match(revertRegex);
 
         if (match) {
-            sha = match[1].slice(0, 7);
+            sha = match[1];
 
             // only exclude this revert if we can find the commit it reverts
             if (typeof shaIndexMap[sha] !== "undefined") {
@@ -194,14 +194,24 @@ function calculateReleaseFromGitLogs(currentVersion, logs, prereleaseId) {
     logs = excludeReverts(parseLogs(logs));
 
     var changelog = {},
-        releaseInfo = {
-            version: currentVersion,
-            type: "",
-            changelog: changelog,
-            rawChangelog: logs.map(function(log) {
-                return log.raw;
-            }).join("\n")
-        };
+        repository = getPackageInfo().repository;
+
+    /**
+     * Generates a formatted line with a link to commits on GitHub
+     * @param {string} log A parsed log message with a full commit hash
+     * @returns {string} A line for a changelog with a link to the GitHub commit
+     */
+    function generateChangelogLine(log) {
+        return log.raw.replace(/^\* ([0-9a-f]{40})/, function(_, hash) {
+            return "* [`" + hash.slice(0, 7) + "`](https://github.com/" + repository + "/commit/" + hash + ")";
+        });
+    }
+    var releaseInfo = {
+        version: currentVersion,
+        type: "",
+        changelog: changelog,
+        rawChangelog: logs.map(generateChangelogLine).join("\n")
+    };
 
     // arrange change types into categories
     logs.forEach(function(log) {
@@ -215,7 +225,7 @@ function calculateReleaseFromGitLogs(currentVersion, logs, prereleaseId) {
             changelog[log.flag] = [];
         }
 
-        changelog[log.flag].push(log.raw);
+        changelog[log.flag].push(generateChangelogLine(log));
     });
 
     if (changelog.breaking) {
@@ -251,7 +261,7 @@ function calculateReleaseInfo(prereleaseId) {
         commitRange = lastTag ? lastTag + "..HEAD" : "";
 
     // get log statements
-    var logs = ShellOps.execSilent("git log --no-merges --pretty=format:\"* %h %s (%an)%n%b\" " + commitRange).split(/\n/g);
+    var logs = ShellOps.execSilent("git log --no-merges --pretty=format:\"* %H %s (%an)%n%b\" " + commitRange).split(/\n/g);
     var releaseInfo = calculateReleaseFromGitLogs(pkg.version, logs, prereleaseId);
     releaseInfo.repository = pkg.repository;
     return releaseInfo;

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -49,9 +49,9 @@ describe("ReleaseOps", function() {
 
         it("should create a patch release when only bug fixes are present", function() {
             var logs = [
-                    "* abcdef0 Fix: Something (Foo Bar)",
-                    "* 1234567 Docs: Something else (foobar)",
-                    "* a1b2c3d Fix: Something else (Foo B. Baz)"
+                    "* 5b4812a956935358bf6e48f4d75a9bc998b3fe41 Fix: Something (Foo Bar)",
+                    "* 00a3526f3a6560e4f91d390725b9a70f5d974f89 Docs: Something else (foobar)",
+                    "* 24b2fdb310b89d7aad134df7e8863a5e055ac63f Fix: Something else (Foo B. Baz)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -60,23 +60,27 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     fix: [
-                        "* abcdef0 Fix: Something (Foo Bar)",
-                        "* a1b2c3d Fix: Something else (Foo B. Baz)"
+                        "* [`5b4812a`](https://github.com/eslint/eslint-release/commit/5b4812a956935358bf6e48f4d75a9bc998b3fe41) Fix: Something (Foo Bar)",
+                        "* [`24b2fdb`](https://github.com/eslint/eslint-release/commit/24b2fdb310b89d7aad134df7e8863a5e055ac63f) Fix: Something else (Foo B. Baz)"
                     ],
                     docs: [
-                        "* 1234567 Docs: Something else (foobar)"
+                        "* [`00a3526`](https://github.com/eslint/eslint-release/commit/00a3526f3a6560e4f91d390725b9a70f5d974f89) Docs: Something else (foobar)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`5b4812a`](https://github.com/eslint/eslint-release/commit/5b4812a956935358bf6e48f4d75a9bc998b3fe41) Fix: Something (Foo Bar)",
+                    "* [`00a3526`](https://github.com/eslint/eslint-release/commit/00a3526f3a6560e4f91d390725b9a70f5d974f89) Docs: Something else (foobar)",
+                    "* [`24b2fdb`](https://github.com/eslint/eslint-release/commit/24b2fdb310b89d7aad134df7e8863a5e055ac63f) Fix: Something else (Foo B. Baz)"
+                ].join("\n")
             });
         });
 
         it("should create a minor release when enhancements are present", function() {
             var logs = [
-                    "* f9e8d7c Fix: Something (Author Name)",
-                    "* facecab Docs: Something else (authorname)",
-                    "* dec0ded Fix: Something else (First Last)",
-                    "* facade5 Update: Foo (dotstar)"
+                    "* 34d6f550b2c87e61a70cb201abd3eadebb370453 Fix: Something (Author Name)",
+                    "* 5c5c361cc338d284cac6d170ab7e105e213e1307 Docs: Something else (authorname)",
+                    "* bcdc618488d12184e32a7ba170b443450c3e9e48 Fix: Something else (First Last)",
+                    "* 7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758 Update: Foo (dotstar)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -85,27 +89,32 @@ describe("ReleaseOps", function() {
                 type: "minor",
                 changelog: {
                     fix: [
-                        "* f9e8d7c Fix: Something (Author Name)",
-                        "* dec0ded Fix: Something else (First Last)"
+                        "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Fix: Something (Author Name)",
+                        "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Something else (First Last)"
                     ],
                     docs: [
-                        "* facecab Docs: Something else (authorname)"
+                        "* [`5c5c361`](https://github.com/eslint/eslint-release/commit/5c5c361cc338d284cac6d170ab7e105e213e1307) Docs: Something else (authorname)"
                     ],
                     update: [
-                        "* facade5 Update: Foo (dotstar)"
+                        "* [`7e4ffad`](https://github.com/eslint/eslint-release/commit/7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758) Update: Foo (dotstar)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Fix: Something (Author Name)",
+                    "* [`5c5c361`](https://github.com/eslint/eslint-release/commit/5c5c361cc338d284cac6d170ab7e105e213e1307) Docs: Something else (authorname)",
+                    "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Something else (First Last)",
+                    "* [`7e4ffad`](https://github.com/eslint/eslint-release/commit/7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758) Update: Foo (dotstar)"
+                ].join("\n")
             });
         });
 
         it("should create a major release when breaking changes are present", function() {
             var logs = [
-                    "* abcd123 Fix: Something (githubhandle)",
-                    "* a1b2c3d Docs: Something else (Committer Name)",
-                    "* 321dcba Fix: Something else (Abc D. Efg)",
-                    "* 9876543 Update: Foo (Tina Tester)",
-                    "* 1234567 Breaking: Whatever (Toby Testing)"
+                    "* 34d6f550b2c87e61a70cb201abd3eadebb370453 Fix: Something (githubhandle)",
+                    "* 5c5c361cc338d284cac6d170ab7e105e213e1307 Docs: Something else (Committer Name)",
+                    "* bcdc618488d12184e32a7ba170b443450c3e9e48 Fix: Something else (Abc D. Efg)",
+                    "* 7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758 Update: Foo (Tina Tester)",
+                    "* 00a3526f3a6560e4f91d390725b9a70f5d974f89 Breaking: Whatever (Toby Testing)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
 
@@ -114,39 +123,45 @@ describe("ReleaseOps", function() {
                 type: "major",
                 changelog: {
                     fix: [
-                        "* abcd123 Fix: Something (githubhandle)",
-                        "* 321dcba Fix: Something else (Abc D. Efg)"
+                        "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Fix: Something (githubhandle)",
+                        "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "* a1b2c3d Docs: Something else (Committer Name)"
+                        "* [`5c5c361`](https://github.com/eslint/eslint-release/commit/5c5c361cc338d284cac6d170ab7e105e213e1307) Docs: Something else (Committer Name)"
                     ],
                     update: [
-                        "* 9876543 Update: Foo (Tina Tester)"
+                        "* [`7e4ffad`](https://github.com/eslint/eslint-release/commit/7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758) Update: Foo (Tina Tester)"
                     ],
                     breaking: [
-                        "* 1234567 Breaking: Whatever (Toby Testing)"
+                        "* [`00a3526`](https://github.com/eslint/eslint-release/commit/00a3526f3a6560e4f91d390725b9a70f5d974f89) Breaking: Whatever (Toby Testing)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Fix: Something (githubhandle)",
+                    "* [`5c5c361`](https://github.com/eslint/eslint-release/commit/5c5c361cc338d284cac6d170ab7e105e213e1307) Docs: Something else (Committer Name)",
+                    "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Something else (Abc D. Efg)",
+                    "* [`7e4ffad`](https://github.com/eslint/eslint-release/commit/7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758) Update: Foo (Tina Tester)",
+                    "* [`00a3526`](https://github.com/eslint/eslint-release/commit/00a3526f3a6560e4f91d390725b9a70f5d974f89) Breaking: Whatever (Toby Testing)"
+                ].join("\n")
             });
         });
 
         it("should disregard reverted commits", function() {
             var logs = [
-                    "* abcd123 Docs: Update something in the docs (githubhandle)",
+                    "* 34d6f550b2c87e61a70cb201abd3eadebb370453 Docs: Update something in the docs (githubhandle)",
                     "This is the body.",
                     "It has multiple lines.",
-                    "* a1b2c3d Revert \"Breaking: A breaking change (fixes #1234)\" (Committer Name)",
-                    "This reverts commit abcdef010c481d5da8d2d9b5ef74945e6566166c.",
+                    "* 5c5c361cc338d284cac6d170ab7e105e213e1307 Revert \"Breaking: A breaking change (fixes #1234)\" (Committer Name)",
+                    "This reverts commit 00a3526f3a6560e4f91d390725b9a70f5d974f89.",
                     "This explains why.",
-                    "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
+                    "* bcdc618488d12184e32a7ba170b443450c3e9e48 Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
                     "Describe the bug.",
-                    "* 9876543 Revert \"New: Add cool new feature (fixes #42)\" (Tina Tester)",
-                    "This reverts commit 123456710c481d5da8d2d9b5ef74945e6566166c.",
-                    "* abcdef0 Breaking: A breaking change (fixes #1234) (Cool Committer)",
-                    "* 1234abc Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)",
+                    "* 7e4ffad5c91e4f8a99a95955ec65c5dbe9ae1758 Revert \"New: Add cool new feature (fixes #42)\" (Tina Tester)",
+                    "This reverts commit 6465ce531d607e7f146e56317b9273d0488e0f46.",
+                    "* 00a3526f3a6560e4f91d390725b9a70f5d974f89 Breaking: A breaking change (fixes #1234) (Cool Committer)",
+                    "* 4a0d181ebff8d380b7e250a5519626222add8aaa Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)",
                     "This reverts commit 0123456789abcdeffedcba9876543210a1b2c3d4.",
-                    "* 1234567 New: Add cool new feature (fixes #42) (Toby Testing)",
+                    "* 6465ce531d607e7f146e56317b9273d0488e0f46 New: Add cool new feature (fixes #42) (Toby Testing)",
                     "Something about this change."
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs);
@@ -156,27 +171,27 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     docs: [
-                        "* abcd123 Docs: Update something in the docs (githubhandle)"
+                        "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Docs: Update something in the docs (githubhandle)"
                     ],
                     fix: [
-                        "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)"
+                        "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Fix a bug (fixes #4321) (Abc D. Efg)"
                     ]
                 },
                 rawChangelog: [
-                    "* abcd123 Docs: Update something in the docs (githubhandle)",
-                    "* 321dcba Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
-                    "* 1234abc Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)"
+                    "* [`34d6f55`](https://github.com/eslint/eslint-release/commit/34d6f550b2c87e61a70cb201abd3eadebb370453) Docs: Update something in the docs (githubhandle)",
+                    "* [`bcdc618`](https://github.com/eslint/eslint-release/commit/bcdc618488d12184e32a7ba170b443450c3e9e48) Fix: Fix a bug (fixes #4321) (Abc D. Efg)",
+                    "* [`4a0d181`](https://github.com/eslint/eslint-release/commit/4a0d181ebff8d380b7e250a5519626222add8aaa) Revert \"New: From a previous release (fixes #1234)\" (Foo Bar)"
                 ].join("\n")
             });
         });
 
         it("should create a prerelease when passed a prereleaseId", function() {
             var logs = [
-                    "* abcd123 Fix: Something (githubhandle)",
-                    "* a1b2c3d Docs: Something else (Committer Name)",
-                    "* 321dcba Fix: Something else (Abc D. Efg)",
-                    "* 9876543 Update: Foo (Tina Tester)",
-                    "* 1234567 Breaking: Whatever (Cool Committer)"
+                    "* fbe463916e0b49bc55f37363bf577ee20e0b3da6 Fix: Something (githubhandle)",
+                    "* 7de216285f4d2e96508e6faefd9d8357baaaaec0 Docs: Something else (Committer Name)",
+                    "* cd06fd502d106d10821227fd2d2ff77f7332c100 Fix: Something else (Abc D. Efg)",
+                    "* 7413ef1a8f5ddca092a1afbd06559b826f7956d3 Update: Foo (Tina Tester)",
+                    "* 7e8a43b2b6350e13a61858f33b4099c964cdd758 Breaking: Whatever (Cool Committer)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("1.0.0", logs, "alpha");
 
@@ -185,28 +200,34 @@ describe("ReleaseOps", function() {
                 type: "major",
                 changelog: {
                     fix: [
-                        "* abcd123 Fix: Something (githubhandle)",
-                        "* 321dcba Fix: Something else (Abc D. Efg)"
+                        "* [`fbe4639`](https://github.com/eslint/eslint-release/commit/fbe463916e0b49bc55f37363bf577ee20e0b3da6) Fix: Something (githubhandle)",
+                        "* [`cd06fd5`](https://github.com/eslint/eslint-release/commit/cd06fd502d106d10821227fd2d2ff77f7332c100) Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "* a1b2c3d Docs: Something else (Committer Name)"
+                        "* [`7de2162`](https://github.com/eslint/eslint-release/commit/7de216285f4d2e96508e6faefd9d8357baaaaec0) Docs: Something else (Committer Name)"
                     ],
                     update: [
-                        "* 9876543 Update: Foo (Tina Tester)"
+                        "* [`7413ef1`](https://github.com/eslint/eslint-release/commit/7413ef1a8f5ddca092a1afbd06559b826f7956d3) Update: Foo (Tina Tester)"
                     ],
                     breaking: [
-                        "* 1234567 Breaking: Whatever (Cool Committer)"
+                        "* [`7e8a43b`](https://github.com/eslint/eslint-release/commit/7e8a43b2b6350e13a61858f33b4099c964cdd758) Breaking: Whatever (Cool Committer)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`fbe4639`](https://github.com/eslint/eslint-release/commit/fbe463916e0b49bc55f37363bf577ee20e0b3da6) Fix: Something (githubhandle)",
+                    "* [`7de2162`](https://github.com/eslint/eslint-release/commit/7de216285f4d2e96508e6faefd9d8357baaaaec0) Docs: Something else (Committer Name)",
+                    "* [`cd06fd5`](https://github.com/eslint/eslint-release/commit/cd06fd502d106d10821227fd2d2ff77f7332c100) Fix: Something else (Abc D. Efg)",
+                    "* [`7413ef1`](https://github.com/eslint/eslint-release/commit/7413ef1a8f5ddca092a1afbd06559b826f7956d3) Update: Foo (Tina Tester)",
+                    "* [`7e8a43b`](https://github.com/eslint/eslint-release/commit/7e8a43b2b6350e13a61858f33b4099c964cdd758) Breaking: Whatever (Cool Committer)"
+                ].join("\n")
             });
         });
 
         it("should create a prerelease when passed a prereleaseId and prerelease version", function() {
             var logs = [
-                    "* abcd123 Fix: Something (githubhandle)",
-                    "* a1b2c3d Docs: Something else (Committer Name)",
-                    "* 321dcba Fix: Something else (Abc D. Efg)"
+                    "* eda81fc28943d51377851295c5c09682496fb9ac Fix: Something (githubhandle)",
+                    "* 0c07d6ac037076557e34d569cd0290e529b3318a Docs: Something else (Committer Name)",
+                    "* 196d32dbfb7cb37b886e7c4ba0adff499c6b26ac Fix: Something else (Abc D. Efg)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("2.0.0-alpha.0", logs, "alpha");
 
@@ -215,22 +236,26 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     fix: [
-                        "* abcd123 Fix: Something (githubhandle)",
-                        "* 321dcba Fix: Something else (Abc D. Efg)"
+                        "* [`eda81fc`](https://github.com/eslint/eslint-release/commit/eda81fc28943d51377851295c5c09682496fb9ac) Fix: Something (githubhandle)",
+                        "* [`196d32d`](https://github.com/eslint/eslint-release/commit/196d32dbfb7cb37b886e7c4ba0adff499c6b26ac) Fix: Something else (Abc D. Efg)"
                     ],
                     docs: [
-                        "* a1b2c3d Docs: Something else (Committer Name)"
+                        "* [`0c07d6a`](https://github.com/eslint/eslint-release/commit/0c07d6ac037076557e34d569cd0290e529b3318a) Docs: Something else (Committer Name)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`eda81fc`](https://github.com/eslint/eslint-release/commit/eda81fc28943d51377851295c5c09682496fb9ac) Fix: Something (githubhandle)",
+                    "* [`0c07d6a`](https://github.com/eslint/eslint-release/commit/0c07d6ac037076557e34d569cd0290e529b3318a) Docs: Something else (Committer Name)",
+                    "* [`196d32d`](https://github.com/eslint/eslint-release/commit/196d32dbfb7cb37b886e7c4ba0adff499c6b26ac) Fix: Something else (Abc D. Efg)"
+                ].join("\n")
             });
         });
 
         it("should gracefully handle unformatted commit messages", function() {
             var logs = [
-                    "* 059f6bd 0.4.0-alpha.4 (Nicholas C. Zakas)",
-                    "* 6b498ed Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
-                    "* 2578f31 Fix: Changelog output (Nicholas C. Zakas)"
+                    "* 70222e95932d3a391ac5717252e13b478d686ba9 0.4.0-alpha.4 (Nicholas C. Zakas)",
+                    "* d52a55e0572fbef1b702abfeefab9f53ff36d121 Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
+                    "* 1934e59323448afd864acc1db712ef8ef730af1a Fix: Changelog output (Nicholas C. Zakas)"
                 ],
                 releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("0.4.0-alpha.4", logs, "alpha");
 
@@ -239,39 +264,19 @@ describe("ReleaseOps", function() {
                 type: "patch",
                 changelog: {
                     build: [
-                        "* 6b498ed Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)"
+                        "* [`d52a55e`](https://github.com/eslint/eslint-release/commit/d52a55e0572fbef1b702abfeefab9f53ff36d121) Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)"
                     ],
                     fix: [
-                        "* 2578f31 Fix: Changelog output (Nicholas C. Zakas)"
+                        "* [`1934e59`](https://github.com/eslint/eslint-release/commit/1934e59323448afd864acc1db712ef8ef730af1a) Fix: Changelog output (Nicholas C. Zakas)"
                     ]
                 },
-                rawChangelog: logs.join("\n")
+                rawChangelog: [
+                    "* [`70222e9`](https://github.com/eslint/eslint-release/commit/70222e95932d3a391ac5717252e13b478d686ba9) 0.4.0-alpha.4 (Nicholas C. Zakas)",
+                    "* [`d52a55e`](https://github.com/eslint/eslint-release/commit/d52a55e0572fbef1b702abfeefab9f53ff36d121) Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
+                    "* [`1934e59`](https://github.com/eslint/eslint-release/commit/1934e59323448afd864acc1db712ef8ef730af1a) Fix: Changelog output (Nicholas C. Zakas)"
+                ].join("\n")
             });
         });
-
-        // https://github.com/eslint/eslint-release/issues/15
-        it("should gracefully handle commit shorthashes longer than 7 characters", function() {
-            var logs = [
-                    "* 6b498edabcde Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)",
-                    "* 2578f31000 Fix: Changelog output (Nicholas C. Zakas)"
-                ],
-                releaseInfo = ReleaseOps.calculateReleaseFromGitLogs("0.4.0-alpha.4", logs, "alpha");
-
-            assert.deepEqual(releaseInfo, {
-                version: "0.4.0-alpha.5",
-                type: "patch",
-                changelog: {
-                    build: [
-                        "* 6b498edabcde Build: package.json and changelog update for 0.4.0-alpha.4 (Nicholas C. Zakas)"
-                    ],
-                    fix: [
-                        "* 2578f31000 Fix: Changelog output (Nicholas C. Zakas)"
-                    ]
-                },
-                rawChangelog: logs.join("\n")
-            });
-        });
-
     });
 
 });


### PR DESCRIPTION
This updates the changelog generator to link to commits on GitHub when generating changelogs. This should also fix the issue where commit shorthashes are ambiguous, resulting in a 404 in links from generated blogposts for ESLint.