### PR TITLE
Update: Major version changelogs include all prereleases

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -277,7 +277,9 @@ function getChangelogCommitRange(tags, prereleaseId) {
 }
 
 /**
- * Gets all changes since the last tag that represents a version.
+ * Gets all changes for this release.
+ * If this will be the first stable release following a prerelease sequence,
+ * all changes from all prereleases since the last stable release are included.
  * @param {string} [prereleaseId] The prerelease identifier if this is a prerelease.
  * @returns {Object} An object containing all the changes since the last version.
  * @private

--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -250,6 +250,33 @@ function calculateReleaseFromGitLogs(currentVersion, logs, prereleaseId) {
 }
 
 /**
+ * Gets the range of commits to include in a changelog.
+ * If this will be the first stable release following a prerelease sequence,
+ * all commits going back to the previous stable release are included.
+ * @param {string[]} tags All prior version tags.
+ * @param {string} [prereleaseId] The prerelease identifier if this is a prerelease.
+ * @returns {string} The commit range to include in the changelog.
+ * @private
+ */
+function getChangelogCommitRange(tags, prereleaseId) {
+    let lastTag = null;
+
+    // If this will be a stable release after a prerelease...
+    if (!prereleaseId && semver.prerelease(tags[tags.length - 1])) {
+        let i = 2;
+
+        do {
+            lastTag = tags[tags.length - i];
+            i++;
+        } while (semver.prerelease(lastTag));
+    } else {
+        lastTag = tags[tags.length - 1];
+    }
+
+    return lastTag ? `${lastTag}..HEAD` : "";
+}
+
+/**
  * Gets all changes since the last tag that represents a version.
  * @param {string} [prereleaseId] The prerelease identifier if this is a prerelease.
  * @returns {Object} An object containing all the changes since the last version.
@@ -257,11 +284,10 @@ function calculateReleaseFromGitLogs(currentVersion, logs, prereleaseId) {
  */
 function calculateReleaseInfo(prereleaseId) {
 
-    // get most recent tag
+    // get last version tag
     const pkg = getPackageInfo(),
         tags = getVersionTags(),
-        lastTag = tags[tags.length - 1],
-        commitRange = lastTag ? `${lastTag}..HEAD` : "";
+        commitRange = getChangelogCommitRange(tags, prereleaseId);
 
     // get log statements
     const logs = ShellOps.execSilent(`git log --no-merges --pretty=format:"* %H %s (%an)%n%b" ${commitRange}`).split(/\n/g);
@@ -427,6 +453,7 @@ module.exports = {
     generateRelease,
     publishRelease,
     calculateReleaseInfo,
+    getChangelogCommitRange,
     calculateReleaseFromGitLogs,
     writeChangelog
 };


### PR DESCRIPTION
For a new stable release following a prerelease sequence, the changelog will include the commits for all of the prereleases going back to the last stable release. For example, given the following release sequence:

- 6.7.8
- 6.8.0
- 7.0.0-alpha.0
- 7.0.0-alpha.1
- 7.0.0

The `7.0.0` changelog will include all changes since `6.8.0`, whereas the `7.0.0-alpha.1` changelog will include only changes since `7.0.0-alpha.0`.

If we prefer to include all changes going back to the previous stable release even for prerelease changelogs, that's an easy change and actually simplifies the logic a bit.