### PR TITLE
Fix: use global-import shelljs

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -328,7 +328,7 @@ function writeChangelog(releaseInfo) {
     }
 
     // switch-o change-o
-    // `cat` returns a `ShellString`. Convert to string to write to file.
+    // `cat` returns a ShellString and `fs.writeFileSync` is throwing an error saying that this must be a String.
     fs.writeFileSync("CHANGELOG.md.tmp", cat("CHANGELOG.tmp", "CHANGELOG.md").toString());
     rm("CHANGELOG.tmp");
     rm("CHANGELOG.md");

--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -5,15 +5,19 @@
  * MIT License
  */
 
+/* global test, cat, rm, mv */
+
 "use strict";
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
+// TODO: Update to use non-global module to avoid prototype pollution.
+require("shelljs/global");
+
 const fs = require("fs"),
     path = require("path"),
-    shelljs = require("shelljs"),
     semver = require("semver"),
     GitHub = require("github-api"),
     dateformat = require("dateformat"),
@@ -44,7 +48,7 @@ function getPackageInfo() {
  * @private
  */
 function validateSetup() {
-    if (!shelljs.test("-f", "package.json")) {
+    if (!test("-f", "package.json")) {
         console.error("Missing package.json file");
         ShellOps.exit(1);
     }
@@ -319,15 +323,16 @@ function writeChangelog(releaseInfo) {
     (`\n${releaseInfo.rawChangelog}\n`).toEnd("CHANGELOG.tmp");
 
     // ensure there's a CHANGELOG.md file
-    if (!shelljs.test("-f", "CHANGELOG.md")) {
+    if (!test("-f", "CHANGELOG.md")) {
         fs.writeFileSync("CHANGELOG.md", "");
     }
 
     // switch-o change-o
-    fs.writeFileSync("CHANGELOG.md.tmp", shelljs.cat("CHANGELOG.tmp", "CHANGELOG.md"));
-    shelljs.rm("CHANGELOG.tmp");
-    shelljs.rm("CHANGELOG.md");
-    shelljs.mv("CHANGELOG.md.tmp", "CHANGELOG.md");
+    // `cat` returns a `ShellString`. Convert to string to write to file.
+    fs.writeFileSync("CHANGELOG.md.tmp", cat("CHANGELOG.tmp", "CHANGELOG.md").toString());
+    rm("CHANGELOG.tmp");
+    rm("CHANGELOG.md");
+    mv("CHANGELOG.md.tmp", "CHANGELOG.md");
 }
 
 /**


### PR DESCRIPTION
`ReleaseOps.writeChangelog()` is currently broken because the local-import `shelljs` module doesn't add `String.prototype.to()`. I'm honestly not sure how this ever worked - I tried locking the version of `shelljs` to 0.8.3 and 0.8.2 and the problem persisted in both (we have `^0.8.3` in `package.json`).

I'll follow up with another PR after the 7.0.0 release that goes back to the local-import `shelljs` module and adds tests for `writeChangelog()` (we currently don't have any).