### PR TITLE
Fix: add blank line between changelog and last version

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -320,7 +320,7 @@ function writeChangelog(releaseInfo) {
     (`v${releaseInfo.version} - ${timestamp}\n`).to("CHANGELOG.tmp");
 
     // output changelog
-    (`\n${releaseInfo.rawChangelog}\n`).toEnd("CHANGELOG.tmp");
+    (`\n${releaseInfo.rawChangelog}\n\n`).toEnd("CHANGELOG.tmp");
 
     // ensure there's a CHANGELOG.md file
     if (!test("-f", "CHANGELOG.md")) {


### PR DESCRIPTION
Add blank line between changelog and last version in the changelog.

fixes https://github.com/eslint/eslint/pull/13396