### PR TITLE
Fix: typo in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
-    - name: Install Packages
+    - name: Install dependencies
       run: npm install
     - name: Test
       run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '12.x'
       - name: Install dependencies
         run: npm install
-      - name: Lint Files
+      - name: Lint files
         run: npm run lint
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  ci:
+  test:
     name: Test
     strategy:
       matrix:
@@ -22,4 +22,4 @@ jobs:
     - name: Install Packages
       run: npm install
     - name: Test
-      run: node test
+      run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches:
       - master
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Lint Files
+        run: npm run lint
+
   test:
     name: Test
     strategy:
@@ -21,5 +35,5 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Install dependencies
       run: npm install
-    - name: Test
+    - name: Run tests
       run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         run: npm install
       - name: Lint Files
         run: npm run lint
-
   test:
     name: Test
     strategy:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint-publish-release": "./bin/eslint-publish-release.js"
   },
   "scripts": {
-    "test": "npm run lint && mocha tests/lib/*.js",
+    "test": "mocha tests/lib/*.js",
     "lint": "eslint .",
     "generate-alpharelease": "node ./bin/eslint-generate-prerelease.js alpha",
     "generate-betarelease": "node ./bin/eslint-generate-prerelease.js beta",


### PR DESCRIPTION
Accidentally pushed https://github.com/eslint/eslint-release/commit/60eb52884c9d5a4e51001110d216959cc3974e57 to `master` before I could catch this typo (I usually push to GitHub to review the changes in the GitHub view). Sorry about that!