### PR TITLE
Breaking: drop support for Node <10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 13.x, 12.x, 10.x, 8.x]
+        node: [14.x, 13.x, 12.x, 10.x]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint Release Tools",
   "main": "./lib/release-ops",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "bin": {
     "eslint-generate-release": "./bin/eslint-generate-release.js",


### PR DESCRIPTION
This PR drops support for Node 8 now that it's no longer supported by the Node team.