### PR TITLE
Update: Remove specific branch from git push (fixes #42)

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -444,7 +444,7 @@ function publishRelease() {
     }
 
     console.log("Publishing to git");
-    ShellOps.exec("git push origin master --tags");
+    ShellOps.exec("git push --tags");
 
     publishReleaseToGitHub(releaseInfo);
 


### PR DESCRIPTION
This removes the `origin master` part of the `git push` command during a release. This should allow us to use the current branch instead of always `master`, which will facilitate the change over to using `main` as the primary branch.