### PR TITLE
Update: group commits by types in release log (fixes #46)

### DIFF
--- a/lib/release-ops.js
+++ b/lib/release-ops.js
@@ -374,6 +374,30 @@ function generateRelease(prereleaseId) {
 }
 
 /**
+ * Creates release body text from a changelog information.
+ * @param {Object} [changelog] The changelog information.
+ * @returns {string} THe release body text
+ */
+function generateReleaseBody(changelog) {
+    const logFlags = [
+        { flag: "breaking", title: "Breaking Changes" },
+        { flag: "new", title: "Features" },
+        { flag: "update", title: "Enhancements" },
+        { flag: "fix", title: "Bug Fixes" },
+        { flag: "docs", title: "Documentation" },
+        { flag: "upgrade", title: "Dependency Upgrades" },
+        { flag: "build", title: "Build Related" },
+        { flag: "chore", title: "Chores" }
+    ];
+
+    return logFlags
+        .map(({ flag, title }) => ({ title, logs: changelog[flag] }))
+        .filter(({ logs }) => logs && logs.length > 0)
+        .map(({ title, logs }) => `## ${title}\n${logs.join("\n")}`)
+        .join("\n\n");
+}
+
+/**
  * Publishes the release information to GitHub.
  * @param {Object} releaseInfo The release information object.
  * @returns {Promise} A promise that resolves when the operation is complete.
@@ -388,7 +412,7 @@ function publishReleaseToGitHub(releaseInfo) {
 
     return repo.createRelease({
         tag_name: tag, // eslint-disable-line camelcase
-        body: releaseInfo.rawChangelog,
+        body: generateReleaseBody(releaseInfo.changelog),
         prerelease: !!semver.prerelease(releaseInfo.version)
     }).then(() => {
         console.log("Posted release notes to GitHub");
@@ -462,5 +486,6 @@ module.exports = {
     calculateReleaseInfo,
     getChangelogCommitRange,
     calculateReleaseFromGitLogs,
-    writeChangelog
+    writeChangelog,
+    generateReleaseBody
 };

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -342,4 +342,32 @@ describe("ReleaseOps", () => {
         });
     });
 
+    describe("generateReleaseBody()", () => {
+        it("generates a changelog grouped by types", () => {
+            const changelog = {
+                    fix: [
+                        "* [`196d32d`](https://github.com/eslint/eslint-release/commit/196d32dbfb7cb37b886e7c4ba0adff499c6b26ac) Fix: Something else (Abc D. Efg)"
+                    ],
+                    docs: [
+                        "* [`0c07d6a`](https://github.com/eslint/eslint-release/commit/0c07d6ac037076557e34d569cd0290e529b3318a) Docs: Something else (Committer Name)"
+                    ],
+                    breaking: [
+                        "* [`7e8a43b`](https://github.com/eslint/eslint-release/commit/7e8a43b2b6350e13a61858f33b4099c964cdd758) Breaking: Remove API (githubhandle)"
+                    ]
+                },
+                generateReleaseBody = ReleaseOps.generateReleaseBody;
+
+            assert.strictEqual(generateReleaseBody(changelog), [
+                "## Breaking Changes",
+                "* [`7e8a43b`](https://github.com/eslint/eslint-release/commit/7e8a43b2b6350e13a61858f33b4099c964cdd758) Breaking: Remove API (githubhandle)",
+                "",
+                "## Bug Fixes",
+                "* [`196d32d`](https://github.com/eslint/eslint-release/commit/196d32dbfb7cb37b886e7c4ba0adff499c6b26ac) Fix: Something else (Abc D. Efg)",
+                "",
+                "## Documentation",
+                "* [`0c07d6a`](https://github.com/eslint/eslint-release/commit/0c07d6ac037076557e34d569cd0290e529b3318a) Docs: Something else (Committer Name)"
+            ].join("\n"));
+        });
+    });
+
 });


### PR DESCRIPTION
This PR implements #46.

Based on [eslint/eslint:/templates/blogpost.md.ejs](https://github.com/eslint/eslint/blob/master/templates/blogpost.md.ejs).
