### PR TITLE
Fix: env var names are case-insensitive in windows

### DIFF
--- a/lib/shell-ops.js
+++ b/lib/shell-ops.js
@@ -30,10 +30,15 @@ module.exports = {
      */
     getModifiedEnv(platform = process.platform, defaultEnv = process.env) {
         const env = {},
-            pathSeparator = platform === "win32" ? ";" : ":";
+            isWindows = platform === "win32",
+            pathSeparator = isWindows ? ";" : ":";
 
         Object.keys(defaultEnv).forEach(key => {
-            env[key] = defaultEnv[key];
+
+            // environmental variable names are case-insensitive in windows
+            const compatKey = isWindows ? key.toUpperCase() : key;
+
+            env[compatKey] = defaultEnv[key];
         });
 
         // modify PATH to use local node_modules


### PR DESCRIPTION
Tests were not passing in my environment while implementing #47.
I am using windows and my path env name was `Path` (not `PATH`).
This caused `env.PATH` to be `undefined`.
Accessing `process.env.PATH` returns the correct value.
This PR fixes this by handling all env names as uppercased names in windows.
