### PR TITLE
Fix: Make npm install work

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,7 @@
 env:
   node: true
-extends: "eslint-config-eslint"
+# extends: "eslint-config-eslint"
+parserOptions:
+  ecmaVersion: 2021
 rules:
   no-console: 0

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "homepage": "https://github.com/eslint/eslint-release#readme",
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-eslint": "^5.0.1",
+    "eslint": "^7.0.0",
     "eslint-plugin-node": "^9.1.0",
     "leche": "^2.3.0",
     "mocha": "^6.1.4",


### PR DESCRIPTION
`npm install` isn't working due to peer dependencies in `eslint-config-eslint`, which is throwing npm 7 into a rage.

This just remove `eslint-config-eslint` for now so we can start developing again. The real fix is to update `eslint-config-eslint`.