### PR TITLE
Chore: upgrade eslint-config-eslint@7.0.0

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,4 +2,6 @@ env:
   node: true
 extends: "eslint-config-eslint"
 rules:
-  no-console: 0
+  no-console: 0  
+  require-unicode-regexp: 0
+  node/no-process-exit: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 13.x, 12.x, 10.x]
+        node: [16.x, 15.x, 14.x, 13.x, 12.x, 10.x]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   "homepage": "https://github.com/eslint/eslint-release#readme",
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-eslint": "^5.0.1",
-    "eslint-plugin-node": "^9.1.0",
+    "eslint": "^7.25.0",
+    "eslint-config-eslint": "^7.0.0",
+    "eslint-plugin-jsdoc": "^32.3.1",
+    "eslint-plugin-node": "^11.1.0",
     "leche": "^2.3.0",
     "mocha": "^6.1.4",
     "sinon": "^1.17.2"


### PR DESCRIPTION
Upgrades `eslint-config-eslint` to v7.0.0, `eslint-plugin-node` to 11.1.0.

Adds `eslint-plugin-jsdoc`, since it is required by the new `eslint-config-eslint`.

Adds Node 15.x and 16.x to test matrix.