### PR TITLE
test: replace `chai` with Node.js `assert` to reduce dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/eslint/eslint-release#readme",
   "devDependencies": {
-    "chai": "^4.2.0",
     "eslint": "^7.25.0",
     "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^32.3.1",

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -11,7 +11,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
     fs = require("fs"),
     leche = require("leche"),
     os = require("os"),

--- a/tests/lib/release-ops.js
+++ b/tests/lib/release-ops.js
@@ -11,7 +11,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("node:assert"),
+const assert = require("assert"),
     fs = require("fs"),
     leche = require("leche"),
     os = require("os"),

--- a/tests/lib/shell-ops.js
+++ b/tests/lib/shell-ops.js
@@ -11,7 +11,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("chai").assert,
+const assert = require("node:assert"),
     sinon = require("sinon"),
     path = require("path"),
     leche = require("leche"),

--- a/tests/lib/shell-ops.js
+++ b/tests/lib/shell-ops.js
@@ -11,7 +11,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("node:assert"),
+const assert = require("assert"),
     sinon = require("sinon"),
     path = require("path"),
     leche = require("leche"),


### PR DESCRIPTION
Hello,

This PR is the follow up PR of https://github.com/eslint/markdown/issues/350.

I've replaced `chai` with Node.js `assert` module to reduce dependency footprint.