### PR TITLE
docs: replace `var` with `const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This command publishes the generate npm package and pushes the changes to GitHub
 You can optionally include the release tool in another Node.js script:
 
 ```js
-var ReleaseOps = require("eslint-release");
+const ReleaseOps = require("eslint-release");
 ```
 
 ## What It Does


### PR DESCRIPTION
Hello,

In this PR, I've replaced `var` with `const` to keep it consistent with the code below and to align with modern JavaScript best practices.

![image](https://github.com/user-attachments/assets/1d0883a6-7ec1-43f5-a5cf-0552c4f398c8)
