### PR TITLE
ci: bump actions version to latest

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@v1
         with:
           project-url: https://github.com/orgs/eslint/projects/3
           github-token: ${{ secrets.PROJECT_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '12.x'
       - name: Install dependencies
@@ -28,8 +28,8 @@ jobs:
         node: [23.x, 22.x, 20.x, 18.x, 16.x, 15.x, 14.x, 13.x, 12.x, 10.x]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Install dependencies


### PR DESCRIPTION
Hello,

In this PR, I've bumped `actions/add-to-project`, `actions/checkout`, and `actions/setup-node` to their latest versions.

- https://github.com/actions/add-to-project
- https://github.com/actions/checkout
- https://github.com/actions/setup-node