### PR TITLE
feat!: drop node<18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - name: Install dependencies
         run: npm install
       - name: Lint files
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [24.x, 22.x, 20.x, 18.x, 16.x, 15.x, 14.x, 13.x, 12.x, 10.x]
+        node: [24.x, 22.x, 20.x, 18.x]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint Release Tools",
   "main": "./lib/release-ops",
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "bin": {
     "eslint-generate-release": "./bin/eslint-generate-release.js",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x ] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Node<18 has been EOL for several years, it's time to drop support for them.
#### What changes did you make? (Give an overview)
Node version support aligns with ESLint v9.
#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

we might need to double-check the node version running on the Jenkins server.