### PR TITLE
test: migrate `sinon` to v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-eslint": "^13.0.0",
     "globals": "^16.4.0",
     "mocha": "^11.0.0",
-    "sinon": "^1.17.2"
+    "sinon": "^21.0.0"
   },
   "dependencies": {
     "dateformat": "^3.0.3",

--- a/tests/lib/release-ops.test.js
+++ b/tests/lib/release-ops.test.js
@@ -487,7 +487,7 @@ describe("ReleaseOps", () => {
         let tmpDir = null;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "writeChangelog-"));
             process.chdir(tmpDir);
         });

--- a/tests/lib/shell-ops.test.js
+++ b/tests/lib/shell-ops.test.js
@@ -57,7 +57,7 @@ describe("ShellOps", () => {
         let sandbox;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
         });
 
         afterEach(() => {
@@ -109,7 +109,7 @@ describe("ShellOps", () => {
         let sandbox;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
         });
 
         afterEach(() => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've migrated `sinon` to v21.

During the major version bump, the only API change was replacing `sinon.sandbox.create()` with `sinon.createSandbox()`, so I've updated the calls accordingly.

<img width="1033" height="162" alt="스크린샷 2025-11-04 172609" src="https://github.com/user-attachments/assets/d87e3e60-6cf6-43e2-9f6b-306a6baf13e2" />

#### What changes did you make? (Give an overview)

In this PR, I've migrated `sinon` to v21.

#### Related Issues

Ref: #85

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
